### PR TITLE
Fixing pre-1900 datetime widget problem.

### DIFF
--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -191,7 +191,10 @@ class DateTimeWidget(Widget):
     def render(self, value):
         if not value:
             return ""
-        return value.strftime(self.formats[0])
+        try:
+            return value.strftime(self.formats[0])
+        except:
+            return datetime_safe.new_date(value).strftime(self.formats[0])
 
 
 class TimeWidget(Widget):


### PR DESCRIPTION
Applying fix from #94 (DateWidget) to issue #93 (same thing but for DateTimeWidget) - use datetime_safe to export pre-1900 dates without errors.
